### PR TITLE
feat: use system prompt translation

### DIFF
--- a/src/catalog/prompts.py
+++ b/src/catalog/prompts.py
@@ -1,5 +1,44 @@
-AGENT_SYSTEM_PROMPT = """Eres chatboxd, un asistente virtual no oficial para la plataforma social de cine Letterboxd.
+PROMPTS = {
+    "ES": {
+        "AGENT_SYSTEM_PROMPT": """Eres chatboxd, un asistente virtual no oficial para la plataforma social de cine Letterboxd.
 Tienes acceso a la base de datos del usuario actual, {username}. Tu tarea es responder a las peticiones del usuario
 mediante la información contenida en la base de datos.
 La fecha de hoy es {current_date}.
 """
+    },
+    "EN": {
+        "AGENT_SYSTEM_PROMPT": """You are chatboxd, an unofficial virtual assistant for the social movie platform Letterboxd.
+You have access to the database of the current user, {username}. Your task is to answer the user queries through the information 
+contained in the database.
+The current date is {current_date}.
+"""
+    },
+    "FR": {
+        "AGENT_SYSTEM_PROMPT": """Vous êtes chatboxd, un assistant virtuel non officiel pour la plateforme sociale de cinéma Letterboxd.
+Vous avez accès à la base de données de l'utilisateur actuel, {username}. Votre tâche est de répondre aux demandes de l'utilisateur
+en utilisant les informations contenues dans la base de données.
+La date d'aujourd'hui est {current_date}.
+"""
+    },
+    "DE": {
+        "AGENT_SYSTEM_PROMPT": """Du bist chatboxd, ein inoffizieller virtueller Assistent für die soziale Filmplattform Letterboxd.
+Du hast Zugriff auf die Datenbank des aktuellen Benutzers, {username}. Deine Aufgabe ist es, die Anfragen des Benutzers zu beantworten,
+indem du die Informationen in der Datenbank nutzt.
+Das heutige Datum ist {current_date}.
+"""
+    },
+    "IT": {
+        "AGENT_SYSTEM_PROMPT": """Sei chatboxd, un assistente virtuale non ufficiale per la piattaforma sociale di cinema Letterboxd.
+Hai accesso al database dell'utente attuale, {username}. Il tuo compito è rispondere alle richieste dell'utente utilizzando le informazioni
+contenute nel database.
+La data di oggi è {current_date}.
+"""
+    },
+    "PT": {
+        "AGENT_SYSTEM_PROMPT": """Você é o chatboxd, um assistente virtual não oficial para a plataforma social de filmes Letterboxd.
+Você tem acesso ao banco de dados do usuário atual, {username}. Sua tarefa é responder às solicitações do usuário usando as informações 
+contidas no banco de dados.
+A data de hoje é {current_date}.
+"""
+    },
+}

--- a/src/services/langgraph_service.py
+++ b/src/services/langgraph_service.py
@@ -7,9 +7,10 @@ from langgraph.graph import StateGraph, START
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import ToolNode, tools_condition
 
-from catalog.prompts import AGENT_SYSTEM_PROMPT
+from catalog.prompts import PROMPTS
 from utils.logger_utils import logger
 from utils.langgraph_utils import State
+from utils.session_utils import get_session_val
 from services.agent_tools import (
     get_movies,
     get_reviews,
@@ -25,8 +26,10 @@ class ChatboxdAgent:
         database=None,
         username=None,
     ):
+        language = get_session_val("language")
+
         self.sys_msg = SystemMessage(
-            content=AGENT_SYSTEM_PROMPT.format(
+            content=PROMPTS[language]["AGENT_SYSTEM_PROMPT"].format(
                 current_date=datetime.today().strftime("%Y-%m-%d"),
                 username=username,
             )


### PR DESCRIPTION
This PR sets the system prompt for the agent in the language chosen by the user, allowing a fluid conversation in any language available.

The downside of this approach is that any modification to the system prompt would have to be applied to each language.