### PR TITLE
Feature/translate tools

### DIFF
--- a/src/catalog/translations.py
+++ b/src/catalog/translations.py
@@ -196,3 +196,48 @@ TRANSLATIONS = {
         ],
     },
 }
+
+TOOL_RESPONSES = {
+    "ES": {
+        "get_reviews_response": "El usuario ha hecho las siguientes reviews de las películas que ha visto:\n",
+        "get_movies_response": "De acuerdo a los filtros proporcionados, el usuario ha visto las siguientes películas:\n",
+        "movie_details_not_found": "No se encontraron detalles de la película",
+        "get_movie_details_response": "🎬 Los detalles de la película son (Añade emojis para que visualmente se vea mejor):\n{movie_detail}\n\nEn ningún caso debes mostrar una imagen ni la sinopsis, ni los Ratings. El diccionario que viene a continuación es irrelevante para ti, no le hagas caso.",
+        "get_graph_response": "No devuelvas ningún dato, la gráfica será mostrada al usuario.",
+    },
+    "EN": {
+        "get_reviews_response": "The user has made the following reviews of the movies they've watched:\n",
+        "get_movies_response": "According to the provided filters, the user has watched the following movies:\n",
+        "movie_details_not_found": "No movie details were found",
+        "get_movie_details_response": "🎬 The details of the movie are (Add emojis to make it visually better):\n{movie_detail}\n\nUnder no circumstances should you show an image, synopsis, or Ratings. The dictionary below is irrelevant to you, do not pay attention to it.",
+        "get_graph_response": "Do not return any data, the graph will be displayed to the user.",
+    },
+    "FR": {
+        "get_reviews_response": "L'utilisateur a écrit les critiques suivantes pour les films qu'il a regardés :\n",
+        "get_movies_response": "Selon les filtres fournis, l'utilisateur a regardé les films suivants :\n",
+        "movie_details_not_found": "Aucun détail du film n'a été trouvé",
+        "get_movie_details_response": "🎬 Les détails du film sont (Ajoutez des émojis pour améliorer la présentation visuelle) :\n{movie_detail}\n\nEn aucun cas, vous ne devez afficher une image, un synopsis ou des notes. Le dictionnaire ci-dessous est sans importance pour vous, ne vous y attardez pas.",
+        "get_graph_response": "Ne retournez aucune donnée, le graphique sera affiché à l'utilisateur.",
+    },
+    "DE": {
+        "get_reviews_response": "Der Benutzer hat die folgenden Rezensionen zu den Filmen geschrieben, die er gesehen hat:\n",
+        "get_movies_response": "Entsprechend den angegebenen Filtern hat der Benutzer die folgenden Filme gesehen:\n",
+        "movie_details_not_found": "Keine Filmdetails gefunden",
+        "get_movie_details_response": "🎬 Die Details des Films sind (Fügen Sie Emojis hinzu, um es visuell besser zu machen):\n{movie_detail}\n\nUnter keinen Umständen sollten Sie ein Bild, eine Zusammenfassung oder Bewertungen anzeigen. Das untenstehende Wörterbuch ist für Sie irrelevant, ignorieren Sie es.",
+        "get_graph_response": "Geben Sie keine Daten zurück, das Diagramm wird dem Benutzer angezeigt.",
+    },
+    "IT": {
+        "get_reviews_response": "L'utente ha scritto le seguenti recensioni dei film che ha visto:\n",
+        "get_movies_response": "Secondo i filtri forniti, l'utente ha visto i seguenti film:\n",
+        "movie_details_not_found": "Dettagli del film non trovati",
+        "get_movie_details_response": "🎬 I dettagli del film sono (Aggiungi emoji per migliorare la visualizzazione):\n{movie_detail}\n\nIn nessun caso devi mostrare un'immagine, una sinossi o le valutazioni. Il dizionario sottostante è irrilevante per te, non farci caso.",
+        "get_graph_response": "Non restituire alcun dato, il grafico sarà mostrato all'utente.",
+    },
+    "PT": {
+        "get_reviews_response": "O usuário fez as seguintes análises dos filmes que assistiu:\n",
+        "get_movies_response": "De acordo com os filtros fornecidos, o usuário assistiu aos seguintes filmes:\n",
+        "movie_details_not_found": "Nenhum detalhe do filme foi encontrado",
+        "get_movie_details_response": "🎬 Os detalhes do filme são (Adicione emojis para melhorar visualmente):\n{movie_detail}\n\nEm nenhuma circunstância você deve mostrar uma imagem, sinopse ou classificações. O dicionário abaixo é irrelevante para você, ignore-o.",
+        "get_graph_response": "Não retorne nenhum dado, o gráfico será exibido ao usuário.",
+    },
+}

--- a/src/services/agent_tools.py
+++ b/src/services/agent_tools.py
@@ -7,6 +7,7 @@ from services.movies_data_service import (
     get_letterboxd_data,
 )
 from utils.logger_utils import logger
+from catalog.translations import TOOL_RESPONSES
 
 
 def get_reviews(
@@ -32,10 +33,7 @@ def get_reviews(
     logger.info(f"🔍 Filters: {filter}")
     reviews = db.filter_reviews(filter)
 
-    return (
-        "El usuario ha hecho las siguientes reviews de las películas que ha visto:\n"
-        + str(reviews)
-    )
+    return TOOL_RESPONSES["EN"]["get_reviews_response"] + str(reviews)
 
 
 def get_movies(
@@ -75,10 +73,7 @@ def get_movies(
     db = Database("letterboxd.db")
     movies = db.filter_diary_entries(filters=filters)
 
-    return (
-        "De acuerdo a los filtros que me has dado, el usuario ha visto las siguiente películas:\n"
-        + str(movies)
-    )
+    return TOOL_RESPONSES["EN"]["get_movies_response"] + str(movies)
 
 
 def get_movie_details_extended(title: str, letterboxd_url: str):
@@ -97,7 +92,7 @@ def get_movie_details_extended(title: str, letterboxd_url: str):
     letterboxd_data = get_letterboxd_data(letterboxd_url)
 
     if omdb_data == {} or letterboxd_data == {}:
-        return "No se encontraron detalles de la película"
+        return TOOL_RESPONSES["EN"]["movie_details_not_found"]
 
     data = {
         "title": letterboxd_data["title"],
@@ -111,9 +106,9 @@ def get_movie_details_extended(title: str, letterboxd_url: str):
     del omdb_data["Ratings"]
 
     return (
-        "🎬 Los detalles de la película son (Añade emojis para que visualmente se vea mejor):\n"
-        + str(omdb_data)
-        + "\n\n  En ningún caso debes mostrar una imagen ni la sinopsis, ni los Ratings. El diccionario que viene a continuación es irrelevante para ti, no lo hagas caso. "
+        TOOL_RESPONSES["EN"]["get_movie_details_response"].format(
+            {"movie_detail": str(omdb_data)}
+        )
     ), {"movies": data}
 
 
@@ -131,16 +126,15 @@ def get_movie_details(letterboxd_url: str):
     letterboxd_data = get_letterboxd_data(letterboxd_url)
 
     if letterboxd_data == {}:
-        return "No se encontraron detalles de la película"
+        return TOOL_RESPONSES["EN"]["movie_details_not_found"]
 
     data = {
         "title": letterboxd_data["title"],
         "url": letterboxd_url,
         "image_url": letterboxd_data["image_url"],
     }
-    return (
-        "🎬 Los detalles de la película son (Añade emojis para que visualmente se vea mejor):\n"
-        + "\n\n  En ningún caso debes mostrar una imagen ni la sinopsis, ni los Ratings. El diccionario que viene a continuación es irrelevante para ti, no lo hagas caso. "
+    return TOOL_RESPONSES["EN"]["get_movie_details_response"].format(
+        {"movie_detail": str(data)}
     ), {"movies": data}
 
 
@@ -159,7 +153,7 @@ def get_graph(movies: List[Dict[str, Any]]):
         "obj_type": "graph",
         "graph_type": GRAPH_TYPES.RATING_DISTRIBUTION.value,
         "data": ratings,
-        "indicaciones": "No devuelvas ningún dato, se le mostrará una gráfica",
+        "indicaciones": TOOL_RESPONSES["EN"]["get_graph_response"],
     }
 
 


### PR DESCRIPTION
Reviewers: @dbenitog @botij0 @mavilam

Description:
--

This PR translates tool descriptions and responses into English, as they were originally written in Spanish.

Tool responses in other languages are included in `catalog/translations.py`, in case they are useful in the future. With the current implementation, it is not possible to access the session language from the tool, so the tool responses cannot be translated to the selected language.